### PR TITLE
Use querystring to encode search queries

### DIFF
--- a/lib/spotify/Spotify.js
+++ b/lib/spotify/Spotify.js
@@ -1,4 +1,5 @@
-var http = require('http');
+var http = require('http'),
+	querystring = require('querystring');
 
 /**
  * Internal method for creating response hollabacks, should not be used on
@@ -57,7 +58,7 @@ module.exports = {
      * @param {Function} The hollaback that'll be invoked once there's data
      */
     search: function(opts, hollaback) {
-        var query = '/search/1/'+opts.type+'.json?q='+opts.query;
+        var query = '/search/1/'+opts.type+'.json?' + querystring.stringify({q: opts.query});
 
         this.get(query, hollaback);
     },


### PR DESCRIPTION
Thanks for this fine API. I have used and found it useful. I noticed that then using query containing special characters like & I received errors.
The proposed change fixes this by using node's querystring api to encode the search query.
