### PR TITLE
Use querystring ecaping for lookup to make encodeUri call obsolete

### DIFF
--- a/lib/spotify/Spotify.js
+++ b/lib/spotify/Spotify.js
@@ -40,12 +40,14 @@ module.exports = {
      * @param {Function} The hollaback that'll be invoked once there's data
      */
     lookup: function(opts, hollaback) {
-        var query = '/lookup/1/.json?uri=spotify:'+opts.type+':'+opts.id;
+        var params = {uri: 'spotify:'+opts.type+':'+opts.id};
 
         if ( opts.type === 'artist' ) {
             // We include album data on artists to give a bit more context
-            query += '&extras=album';
-        }
+            params.extras == 'album';
+        }        
+
+        var query = '/lookup/1/.json?' + querystring.stringify(params);
 
         this.get(query, hollaback);
     },
@@ -73,7 +75,7 @@ module.exports = {
         
         var opts = {
             host: "ws.spotify.com",
-            path: encodeURI(query),
+            path: (query),
             method: "GET"
         },
         request = http.request(opts, makeResponse( hollaback ));


### PR DESCRIPTION
I still had some problems with querying spotify with queries containing special characters. These were caused by the encodeUril call before making the request.
I therefore changed the lookup method to use querystring as well and removed the encodeUri call.
This works for me but I did not test the lookup function. Perhaps you can perform some tests?
Thanks.
