### PR TITLE
Send an error object in the callback in case of non-200 response

### DIFF
--- a/lib/spotify/Spotify.js
+++ b/lib/spotify/Spotify.js
@@ -21,15 +21,22 @@ function makeResponse(hollaback) {
         response.on('end', function() {
             var err, json;
 
-            try {
-                json = JSON.parse( chunks );
-            }
-            catch(e) {
-                err = e;
-                console.log(e);
-            }
+            if (response.statusCode !== 200) {
+                hollaback({
+                    code: response.statusCode,
+                    body: chunks
+                });
+            } else {
+                try {
+                    json = JSON.parse( chunks );
+                }
+                catch(e) {
+                    err = e;
+                    console.log(e);
+                }
 
-            hollaback(err, json);
+                hollaback(err, json);
+            }
         });
     };
 }


### PR DESCRIPTION
While using the library I had a request fail with 502 Bad Gateway. This resulted in a `SyntaxError: Unexpected token <` being returned as `err` in the callback from trying to JSON.parse the response.

Comments on the fix? Not sure about the returned object but it seems like a decent way to return the status code and a possible error description in the body.

```
{ code: 502,
  body: '<head><title>502 Bad Gateway</title></head>\n<body bgcolor="white">\n<center><h1>502 Bad Gateway</h1></center>\n<hr><center>nginx</center>\n</body>\n</html>\n' }
```
