### PR TITLE
Made the lookup clever

### DIFF
--- a/lib/spotify/Spotify.js
+++ b/lib/spotify/Spotify.js
@@ -50,10 +50,11 @@ module.exports = {
      * @param {Function} The hollaback that'll be invoked once there's data
      */
     lookup: function(opts, hollaback) {
-        if ( typeof opts != "string" || opts instanceof Object && opts.type && opts.id )
+        if ( typeof opts !== "string" || opts instanceof Object && opts.type && opts.id ) {
             var params = {uri: 'spotify:'+opts.type+':'+opts.id};
-        else
+        } else {
             var params = {uri: opts}
+        }
 
         if ( opts.type === 'artist' ) {
             // We include album data on artists to give a bit more context


### PR DESCRIPTION
If opts is of type string, we can safely assume a string to lookup is given on purpose; use that. Else, we verify if required objects are given (making the new detection system not break previous changes).
