### PR TITLE
Added command for get several albums endpoint

### DIFF
--- a/lib/spotify/Spotify.js
+++ b/lib/spotify/Spotify.js
@@ -78,5 +78,17 @@ module.exports = {
         request.on('error', function (err) {
             hollaback (err, {});
         });
+    },
+
+    /**
+     * Send a request to the Spotify web service API
+     *
+     * @param {Array} List of spotify ids of albums
+     * @param {Function} The hollaback that'll be invoked once there's data
+     */
+    albums: function(ids, hollaback) {
+      console.log(ids)
+        var query = '/v1/albums?ids=' + ids.join(',')
+        this.get(query, hollaback);
     }
 };


### PR DESCRIPTION
https://developer.spotify.com/web-api/get-several-albums/

Spotify's search endpoint is deficient.  Its albums don't include an artist.  As a workaround, I added support for their albums endpoint, which takes a list of album ids and returns their albums.  This list _does_ have artists.  I can live with making one extra api call to get this info.

FWIW, spotify is aware of the issue but they've been sitting on it since March.  https://github.com/spotify/web-api/issues/11
